### PR TITLE
Manifest live view

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -15,3 +15,8 @@
   cursor: pointer;
   border: 1px solid #444444
 }
+
+.manifest-row-section {
+  margin-top: 20px;
+  width: 90%;
+}

--- a/lib/inflow/import.ex
+++ b/lib/inflow/import.ex
@@ -44,7 +44,6 @@ defmodule Inflow.Import do
     file_path
     |> S3.Upload.stream_file()
     |> S3.upload("artsy-currents-development", "#{manifest.partner_id}/#{manifest.id}.csv")
-    # => :done
     |> ExAws.request()
   end
 

--- a/lib/inflow_web/live/dashboard_view.ex
+++ b/lib/inflow_web/live/dashboard_view.ex
@@ -31,13 +31,16 @@ defmodule InflowWeb.DashboardView do
     matches = fetch_partners(q, socket.assigns.access_token)
     {:noreply, assign(socket, matches: matches)}
   end
-  def handle_event("suggest", _ , socket), do: {:noreply, assign(socket, matches: [])}
 
-  def handle_event("select"<> partner_id, _ , socket) do
+  def handle_event("suggest", _, socket), do: {:noreply, assign(socket, matches: [])}
+
+  def handle_event("select" <> partner_id, _, socket) do
     {:stop,
      socket
      |> put_flash(:info, "Partner Selected")
-     |> redirect(to: InflowWeb.Router.Helpers.manifests_path(socket, :index, %{partner_id: partner_id}))}
+     |> redirect(
+       to: InflowWeb.Router.Helpers.manifests_path(socket, :index, %{partner_id: partner_id})
+     )}
   end
 
   defp fetch_partners(term, token) do

--- a/lib/inflow_web/live/manifest_live_view.ex
+++ b/lib/inflow_web/live/manifest_live_view.ex
@@ -8,7 +8,15 @@ defmodule InflowWeb.ManifestLiveView do
     <%= if @loading do %>
       <div> Loading </div>
     <% else %>
-      <div> <%= @manifest.state %> </div>
+      <div><strong> <%= @manifest.state %> </strong></div>
+      <table class="manifest-row-section">
+        <%= for mr <- @manifest_rows do %>
+          <tr class="manifest-row">
+            <td> <%= mr.name %></td>
+            <td> <%= mr.title %></td>
+          </tr>
+        <% end %>
+      </table>
     <% end %>
     """
   end
@@ -24,6 +32,7 @@ defmodule InflowWeb.ManifestLiveView do
        id: manifest_id,
        manifest: nil,
        loading: true,
+       manifest_rows: [],
        access_token: session.access_token
      )}
   end
@@ -37,7 +46,7 @@ defmodule InflowWeb.ManifestLiveView do
     {:noreply, assign(socket, manifest: %Manifest{socket.assigns.manifest | state: state})}
   end
 
-  def handle_info(%{event: "manifest_row_updated", payload: %{manifest_row_id: manifest_row_id, state: state}}, socket) do
-    {:noreply, assign(socket, manifest: %Manifest{socket.assigns.manifest | state: state})}
+  def handle_info(%{event: "manifest_row_created", payload: %{manifest_row: manifest_row}}, socket) do
+    {:noreply, assign(socket, manifest_rows: socket.assigns.manifest_rows ++ [manifest_row])}
   end
 end

--- a/lib/inflow_web/live/manifest_live_view.ex
+++ b/lib/inflow_web/live/manifest_live_view.ex
@@ -5,7 +5,7 @@ defmodule InflowWeb.ManifestLiveView do
 
   def render(assigns) do
     ~L"""
-    <% if @loading do %>
+    <%= if @loading do %>
       <div> Loading </div>
     <% else %>
       <div> <%= @manifest.state %> </div>
@@ -15,7 +15,6 @@ defmodule InflowWeb.ManifestLiveView do
 
   def mount(session, socket) do
     manifest_id = session.manifest_id
-    IO.inspect(manifest_id)
     if connected?(socket) do
       InflowWeb.Endpoint.subscribe(@topic <> manifest_id)
       send(self(), :initialize)
@@ -31,14 +30,14 @@ defmodule InflowWeb.ManifestLiveView do
 
   def handle_info(:initialize, socket) do
     manifest = Inflow.Import.get_manifest!(socket.assigns.id)
-    IO.inspect(manifest, label: "---->")
     {:noreply, assign(socket, manifest: manifest, loading: false)}
   end
 
-  def handle_info(%{event: @topic <> routing_key, payload: %{state: state}}, socket) do
+  def handle_info(%{event: "manifest_updated", payload: %{state: state}}, socket) do
     {:noreply, assign(socket, manifest: %Manifest{socket.assigns.manifest | state: state})}
   end
-  def handle_info(%{event: @topic <> routing_key, payload: %{manifest_row_id: manifest_row_id, state: state}}, socket) do
+
+  def handle_info(%{event: "manifest_row_updated", payload: %{manifest_row_id: manifest_row_id, state: state}}, socket) do
     {:noreply, assign(socket, manifest: %Manifest{socket.assigns.manifest | state: state})}
   end
 end

--- a/lib/inflow_web/live/manifest_live_view.ex
+++ b/lib/inflow_web/live/manifest_live_view.ex
@@ -1,0 +1,44 @@
+defmodule InflowWeb.ManifestLiveView do
+  use Phoenix.LiveView
+  alias Inflow.Import.Manifest
+  @topic "manifests:"
+
+  def render(assigns) do
+    ~L"""
+    <% if @loading do %>
+      <div> Loading </div>
+    <% else %>
+      <div> <%= @manifest.state %> </div>
+    <% end %>
+    """
+  end
+
+  def mount(session, socket) do
+    manifest_id = session.manifest_id
+    IO.inspect(manifest_id)
+    if connected?(socket) do
+      InflowWeb.Endpoint.subscribe(@topic <> manifest_id)
+      send(self(), :initialize)
+    end
+    {:ok,
+     assign(socket,
+       id: manifest_id,
+       manifest: nil,
+       loading: true,
+       access_token: session.access_token
+     )}
+  end
+
+  def handle_info(:initialize, socket) do
+    manifest = Inflow.Import.get_manifest!(socket.assigns.id)
+    IO.inspect(manifest, label: "---->")
+    {:noreply, assign(socket, manifest: manifest, loading: false)}
+  end
+
+  def handle_info(%{event: @topic <> routing_key, payload: %{state: state}}, socket) do
+    {:noreply, assign(socket, manifest: %Manifest{socket.assigns.manifest | state: state})}
+  end
+  def handle_info(%{event: @topic <> routing_key, payload: %{manifest_row_id: manifest_row_id, state: state}}, socket) do
+    {:noreply, assign(socket, manifest: %Manifest{socket.assigns.manifest | state: state})}
+  end
+end


### PR DESCRIPTION
This is built on top of #6 , 
- When going to a manifest show page, if manifest is still active ("pending", "processing") it goes to a  newly added live view which listens on `manifests:<current manifest id>` topic's pubsub events and updates view based on that. 
You can see it in action by posting events from console:
```elixir
Inflow.Endpoint.broadcast("manifests:<id of this manifest you are on>", "manfiest_updated", %{state: "completed"})
```